### PR TITLE
Koa 2: Upgrade to be a modern, promise-based (ctx, next) middleware

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -14,8 +14,8 @@ $ npm install koa-conditional-get
 ```js
 var conditional = require('koa-conditional-get');
 var etag = require('koa-etag');
-var koa = require('koa');
-var app = koa();
+var Koa = require('koa');
+var app = new Koa();
 
 // use it upstream from etag so
 // that they are present
@@ -28,14 +28,14 @@ app.use(etag());
 
 // respond
 
-app.use(function *(next){
-  yield next;
-
-  this.body = {
-    name: 'tobi',
-    species: 'ferret',
-    age: 2
-  };
+app.use(function(ctx, next){
+  return next().then(function() {
+    ctx.body = {
+      name: 'tobi',
+      species: 'ferret',
+      age: 2
+    };
+  });
 })
 
 app.listen(3000);

--- a/example.js
+++ b/example.js
@@ -1,8 +1,8 @@
 
 var conditional = require('./');
 var etag = require('koa-etag');
-var koa = require('koa');
-var app = koa();
+var Koa = require('koa');
+var app = new Koa();
 
 // use it upstream from etag so
 // that they are present
@@ -15,16 +15,14 @@ app.use(etag());
 
 // respond
 
-app.use(function(next){
-  return function *(){
-    yield next;
-    
-    this.body = {
+app.use(function(ctx, next){
+  return next().then(function() {
+    ctx.body = {
       name: 'tobi',
       species: 'ferret',
       age: 2
     };
-  }
+  });
 })
 
 app.listen(3000);

--- a/index.js
+++ b/index.js
@@ -12,11 +12,12 @@ module.exports = conditional;
  */
 
 function conditional() {
-  return function *conditional(next){
-    yield* next;
-    if (this.fresh) {
-      this.status = 304;
-      this.body = null;
-    }
+  return function conditional(ctx, next) {
+    return next().then(function() {
+      if (ctx.fresh) {
+        ctx.status = 304;
+        ctx.body = null;
+      }
+    });
   }
 }

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
   "devDependencies": {
     "etag": "^1.7.0",
     "istanbul": "^0.4.2",
-    "koa": "^1.0.0",
-    "koa-etag": "^2.1.1",
+    "koa": "^2.0.0-alpha.3",
+    "koa-etag": "^3.0.0",
     "mocha": "^2.0.0",
     "supertest": "^1.0.0"
   },

--- a/test/index.js
+++ b/test/index.js
@@ -3,7 +3,7 @@ var request = require('supertest');
 var calculate = require('etag');
 var conditional = require('..');
 var etag = require('koa-etag');
-var koa = require('koa');
+var Koa = require('koa');
 var fs = require('fs');
 
 var body = {
@@ -15,16 +15,16 @@ var body = {
 describe('conditional()', function(){
   describe('when cache is fresh', function(){
     it('should respond with 304', function(done){
-      var app = koa();
+      var app = new Koa();
 
       app.use(conditional());
       app.use(etag());
 
-      app.use(function *(next){
-        yield next;
-
-        this.body = body;
-      })
+      app.use(function(ctx, next){
+        return next().then(function() {
+          ctx.body = body;
+        });
+      });
 
       request(app.listen())
       .get('/')
@@ -35,16 +35,16 @@ describe('conditional()', function(){
 
   describe('when cache is stale', function(){
     it('should do nothing', function(done){
-      var app = koa();
+      var app = new Koa();
 
       app.use(conditional());
       app.use(etag());
 
-      app.use(function *(next){
-        yield next;
-
-        this.body = body;
-      })
+      app.use(function(ctx, next){
+        return next().then(function() {
+          ctx.body = body;
+        });
+      });
 
       request(app.listen())
       .get('/')


### PR DESCRIPTION
Updates this middleware to support Koa 2. The example server and readme file also reflect the modern API.

Test Plan:
 - `npm test`
 - `node example.js` and visited the page at localhost:3000 and saw that it sent 304s after soft-reloading the page in Chrome